### PR TITLE
Operator chaining fix

### DIFF
--- a/py_rete/conditions.py
+++ b/py_rete/conditions.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from py_rete.common import V
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing import List
+    from typing import Sequence
     from typing import Union
     from typing import Tuple
     from typing import Callable
@@ -26,7 +26,7 @@ class ConditionalList(tuple):
     """
     A conditional that consists of a list of other conditionals.
     """
-    def __new__(cls, *args: List[Union[ConditionalList, ConditionalElement]]):
+    def __new__(cls, *args: Sequence[Union[ConditionalList, ConditionalElement]]):
         return super().__new__(cls, args)
 
     def __repr__(self):
@@ -74,7 +74,12 @@ class OR(ConditionalList, ComposableCond):
 
 
 class NOT(ConditionalList, ComposableCond):
-    pass
+    def __new__(cls, *args: Sequence[Union[ConditionalList, ConditionalElement]]):
+        if len(args) > 1:
+            raise TypeError("NOT takes only one argument, use explicit NOT(AND(...)) or NOT(OR(...))")
+        elif isinstance(args[0], Filter):
+            raise TypeError("NOT doesn't work with Filter() conditions downstream, refactor your rules.")
+        return super().__new__(cls, *args)
 
 
 @dataclass(eq=True, frozen=True)
@@ -91,7 +96,7 @@ class Cond(ConditionalElement, ComposableCond):
         return "(%s ^%s %s)" % (self.identifier, self.attribute, self.value)
 
     @property
-    def vars(self) -> List[Tuple[str, V]]:
+    def vars(self) -> Sequence[Tuple[str, V]]:
         """
         Returns a list of tuples (field, var) that contains the slot names as a
         string and the variable object it maps to.

--- a/py_rete/network.py
+++ b/py_rete/network.py
@@ -233,7 +233,8 @@ class ReteNetwork:
         self.production_counter += 1
         self.productions.add(prod)
 
-        for conds in prod.get_rete_conds():
+        conds_list = prod.get_rete_conds()
+        for conds in conds_list:
             current_node = self.build_or_share_network_for_conditions(
                 self.beta_root, conds, [])
             p_node = self.build_or_share_p(current_node, prod)

--- a/py_rete/network.py
+++ b/py_rete/network.py
@@ -233,8 +233,7 @@ class ReteNetwork:
         self.production_counter += 1
         self.productions.add(prod)
 
-        conds_list = prod.get_rete_conds()
-        for conds in conds_list:
+        for conds in prod.get_rete_conds():
             current_node = self.build_or_share_network_for_conditions(
                 self.beta_root, conds, [])
             p_node = self.build_or_share_p(current_node, prod)

--- a/py_rete/production.py
+++ b/py_rete/production.py
@@ -118,9 +118,13 @@ class Production():
         if pattern is None:
             return ([],)
         disjuncts = compile_disjuncts(pattern)
-        return [list(get_rete_conds(AND(*disjunct)))
-                if isinstance(disjunct, tuple) else
-                list(get_rete_conds(AND(disjunct))) for disjunct in disjuncts]
+        conds = []
+        for disjunct in disjuncts:
+            if isinstance(disjunct, tuple):
+                conds.append(list(get_rete_conds(AND(*disjunct))))
+            else:
+                conds.append(list(get_rete_conds(AND(disjunct))))
+        return conds
 
     def get_rete_conds(self):
         return self._get_rete_conds(self.pattern)

--- a/py_rete/production.py
+++ b/py_rete/production.py
@@ -121,7 +121,13 @@ class Production():
         conds = []
         for disjunct in disjuncts:
             if isinstance(disjunct, tuple):
-                conds.append(list(get_rete_conds(AND(*disjunct))))
+                if len(disjunct) == 1:
+                    if isinstance(disjunct[0], NOT):
+                        conds.append(list(get_rete_conds(disjunct)))
+                    else:
+                        conds.append(list(get_rete_conds(*disjunct)))
+                else:
+                    conds.append(list(get_rete_conds(AND(*disjunct))))
             else:
                 conds.append(list(get_rete_conds(AND(disjunct))))
         return conds

--- a/py_rete/production.py
+++ b/py_rete/production.py
@@ -36,12 +36,11 @@ def dnf(expression):
         return total
     if isinstance(expression, NOT):
         if isinstance(expression[0], NOT):
-            return dnf(AND(*[i for ele in expression for i in ele]))
+            return dnf(AND(*[ele for ele in expression[0]]))
         elif isinstance(expression[0], AND):
-            inner = dnf(OR(*[NOT(ele) for ele in expression[0]]))
-            return inner
+            return dnf(OR(*[NOT(ele) for ele in expression[0]]))
         else:
-            inner = dnf(AND(*[ele for ele in expression]))
+            inner = dnf(AND(expression[0]))
             return [[NOT(*branch) for branch in inner]]
     else:
         return [[expression]]

--- a/py_rete/production.py
+++ b/py_rete/production.py
@@ -27,22 +27,21 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 def dnf(expression):
-    """
-    Compiles a boolean expression into "Disjunctive normal form".
-    """
     if isinstance(expression, OR):
-        return (se for e in expression for se in dnf(e))
+        return list(se for e in expression for se in dnf(e))
     if isinstance(expression, AND):
         total = []
         for sub_expression in product(*[dnf(e) for e in expression]):
             total.append(list(se for e in sub_expression for se in e))
         return total
     if isinstance(expression, NOT):
+        if len(expression) == 1 and isinstance(expression[0], NOT):
+            return dnf(AND(*[i for ele in expression for i in ele]))
         inner = dnf(AND(*[ele for ele in expression]))
-        # list means implicit OR
-        return [[NOT(*branch) if isinstance(branch, list) else NOT(branch) for branch in inner]]
+        return [[NOT(*branch) for branch in inner]]
     else:
         return [[expression]]
+
 
 def get_rete_conds(it):
     for ele in it:

--- a/py_rete/production.py
+++ b/py_rete/production.py
@@ -35,10 +35,14 @@ def dnf(expression):
             total.append(list(se for e in sub_expression for se in e))
         return total
     if isinstance(expression, NOT):
-        if len(expression) == 1 and isinstance(expression[0], NOT):
+        if isinstance(expression[0], NOT):
             return dnf(AND(*[i for ele in expression for i in ele]))
-        inner = dnf(AND(*[ele for ele in expression]))
-        return [[NOT(*branch) for branch in inner]]
+        elif isinstance(expression[0], AND):
+            inner = dnf(OR(*[NOT(ele) for ele in expression[0]]))
+            return inner
+        else:
+            inner = dnf(AND(*[ele for ele in expression]))
+            return [[NOT(*branch) for branch in inner]]
     else:
         return [[expression]]
 

--- a/py_rete/production.py
+++ b/py_rete/production.py
@@ -113,13 +113,17 @@ class Production():
             for token in node.activations:
                 yield token
 
-    def get_rete_conds(self):
-        if self.pattern is None:
+    @staticmethod
+    def _get_rete_conds(pattern):
+        if pattern is None:
             return ([],)
-        disjuncts = compile_disjuncts(self.pattern)
+        disjuncts = compile_disjuncts(pattern)
         return [list(get_rete_conds(AND(*disjunct)))
                 if isinstance(disjunct, tuple) else
                 list(get_rete_conds(AND(disjunct))) for disjunct in disjuncts]
+
+    def get_rete_conds(self):
+        return self._get_rete_conds(self.pattern)
 
     def fire(self, token: Token):
         kwargs = {arg: self._rete_net if arg == 'net' else

--- a/py_rete/production.py
+++ b/py_rete/production.py
@@ -106,18 +106,12 @@ class Production():
             for token in node.activations:
                 yield token
 
-    @staticmethod
-    def _get_rete_conds(pattern):
-        if pattern is None:
-            return ([],)
-        disjuncts = dnf(pattern)
-        conds = []
-        for disjunct in disjuncts:
-            conds.append(list(get_rete_conds(disjunct)))
-        return conds
-
     def get_rete_conds(self):
-        return self._get_rete_conds(self.pattern)
+        if self.pattern is None:
+            return ([],)
+        disjuncts = dnf(self.pattern)
+        return [list(get_rete_conds(disjunct)) for disjunct in disjuncts]
+
 
     def fire(self, token: Token):
         kwargs = {arg: self._rete_net if arg == 'net' else

--- a/py_rete/production.py
+++ b/py_rete/production.py
@@ -27,6 +27,23 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 def dnf(expression):
+    """
+    Disjunctive normal form.
+
+    Converts a Boolean sequence to disjunctive normal form, i.e. OR of ANDs, or
+    a disjunction of conjunctions.
+
+    Conversions:
+    1. ~(~A)        =>   A
+    2. ~(A & B)     =>  ~A | ~B
+    3. ~(A | B)     =>  ~A & ~B
+    4. A & (B | C)  =>  (A & B) | (A & C)
+    4. (A | B) & C  =>  (A & C) | (B & C)
+
+    Returns: A list of lists, where top level list contains OR'd sequences of
+    AND'd conditions.
+    E.g. [[A, B], [C]] equals (A & B) | C
+    """
     if isinstance(expression, OR):
         return list(se for e in expression for se in dnf(e))
     if isinstance(expression, AND):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -242,7 +242,7 @@ def test_add_remove_join():
 def test_add_remove_ncc():
     net = ReteNetwork()
 
-    @Production(~Fact(first="hello", second="world"))
+    @Production(NOT(Fact(first="hello", second="world")))
     def ncc_fun():
         pass
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -242,7 +242,7 @@ def test_add_remove_join():
 def test_add_remove_ncc():
     net = ReteNetwork()
 
-    @Production(NOT(Fact(first="hello", second="world")))
+    @Production(~Fact(first="hello", second="world"))
     def ncc_fun():
         pass
 

--- a/tests/test_beta.py
+++ b/tests/test_beta.py
@@ -122,13 +122,13 @@ class TestOr:
         assert len(list(net.matches)) == count
 
     def test_or_false_false(self):
-        self.check_matches(Production(Filter(lambda: False) | Filter(lambda:False)), 0)
+        self.check_matches(Production(Filter(lambda: False) | Filter(lambda: False)), 0)
     def test_or_false_true(self):
-        self.check_matches(Production(Filter(lambda: False) | Filter(lambda:True)), 1)
+        self.check_matches(Production(Filter(lambda: False) | Filter(lambda: True)), 1)
     def test_or_true_false(self):
-        self.check_matches(Production(Filter(lambda: True) | Filter(lambda:False)), 1)
+        self.check_matches(Production(Filter(lambda: True) | Filter(lambda: False)), 1)
     def test_or_true_true(self):
-        self.check_matches(Production(Filter(lambda: True) | Filter(lambda:True)), 2)
+        self.check_matches(Production(Filter(lambda: True) | Filter(lambda: True)), 2)
 
 
 class TestOperatorChaining:
@@ -144,51 +144,51 @@ class TestOperatorChaining:
         def a(): pass
         def b(): pass
         def c(): pass
-        c1 = OR(Filter(a),AND(Filter(b), Filter(c)))
+        c1 = OR(Filter(a), AND(Filter(b), Filter(c)))
         c2 = Filter(a) | Filter(b) & Filter(c)
         assert c1 == c2
 
     def test_or_and(self):
-        self.check_matches(Production(Filter(lambda: False) | Filter(lambda:False) & Filter(lambda:False)), 0)
+        self.check_matches(Production(Filter(lambda: False) | Filter(lambda: False) & Filter(lambda: False)), 0)
     def test_or_and2(self):
-        self.check_matches(Production((Filter(lambda: True) | Filter(lambda:False)) & Filter(lambda:False)), 0)
+        self.check_matches(Production((Filter(lambda: True) | Filter(lambda: False)) & Filter(lambda: False)), 0)
     def test_or_and3(self):
         # (True | (False & False)) => True
-        self.check_matches(Production(Filter(lambda: True) | (Filter(lambda:False) & Filter(lambda:False))), 1)
+        self.check_matches(Production(Filter(lambda: True) | (Filter(lambda: False) & Filter(lambda: False))), 1)
     def test_and_or1(self):
-        self.check_matches(Production(Filter(lambda: False) & Filter(lambda:False) | Filter(lambda:False)), 0)
+        self.check_matches(Production(Filter(lambda: False) & Filter(lambda: False) | Filter(lambda: False)), 0)
     def test_and_or2(self):
-        self.check_matches(Production(Filter(lambda: True) & Filter(lambda:False) | Filter(lambda:False)), 0)
+        self.check_matches(Production(Filter(lambda: True) & Filter(lambda: False) | Filter(lambda: False)), 0)
     def test_and_or3(self):
-        self.check_matches(Production(Filter(lambda: False) & Filter(lambda:True) | Filter(lambda:False)), 0)
+        self.check_matches(Production(Filter(lambda: False) & Filter(lambda: True) | Filter(lambda: False)), 0)
     def test_and_or4(self):
         # (False & False | True) => True
-        self.check_matches(Production(Filter(lambda: False) & Filter(lambda:False) | Filter(lambda:True)), 1)
+        self.check_matches(Production(Filter(lambda: False) & Filter(lambda: False) | Filter(lambda: True)), 1)
     def test_and_or5(self):
         # (True & True | False) => True
-        self.check_matches(Production(Filter(lambda: True) & Filter(lambda:True) | Filter(lambda:False)), 1)
+        self.check_matches(Production(Filter(lambda: True) & Filter(lambda: True) | Filter(lambda: False)), 1)
     def test_and_or6(self):
         # (True & False | True) => True
-        self.check_matches(Production(Filter(lambda: True) & Filter(lambda:False) | Filter(lambda:True)), 1)
+        self.check_matches(Production(Filter(lambda: True) & Filter(lambda: False) | Filter(lambda: True)), 1)
     def test_and_or7(self):
         # (False & True | True) => True
-        self.check_matches(Production(Filter(lambda: False) & Filter(lambda:True) | Filter(lambda:True)), 1)
+        self.check_matches(Production(Filter(lambda: False) & Filter(lambda: True) | Filter(lambda: True)), 1)
     def test_and_or8(self):
         # (True & True | True) => True
-        self.check_matches(Production(Filter(lambda: True) & Filter(lambda:True) | Filter(lambda:True)), 2)
+        self.check_matches(Production(Filter(lambda: True) & Filter(lambda: True) | Filter(lambda: True)), 2)
 
     def test_long_chain(self):
         # True & (False | (True & False)) => False
         self.check_matches(Production(
             Filter(lambda: True)
-            &  (Filter(lambda:False) | (Filter(lambda: True) & Filter(lambda:False)))
+            &  (Filter(lambda: False) | (Filter(lambda: True) & Filter(lambda: False)))
             ),
         0)
 
     def test_long_chain_not(self):
         # True & (False | (True & NOT(False))) => True
         self.check_matches(Production(Filter(lambda: True)
-            &  (Filter(lambda:False) | (Filter(lambda: True) & NOT(Fact())))
+            &  (Filter(lambda: False) | (Filter(lambda: True) & NOT(Fact())))
             ),
         1)
 
@@ -431,7 +431,7 @@ def test_ncc():
     c2 = Cond(V('z'), 'color', 'red')
     c3 = Cond(V('z'), 'on', V('w'))
 
-    #@Production(AND(c0, c1, NOT(AND(c2, c3))))
+    # @Production(AND(c0, c1, NOT(AND(c2, c3))))
     @Production(c0 & c1 & ~(c2 & c3))
     def p0():
         pass
@@ -444,26 +444,23 @@ def test_ncc():
     net.add_production(p1)
 
     wmes = [
-        WME('B1', 'on', 'B2'),       #
-        WME('B1', 'on', 'B3'),       #
-        WME('B1', 'color', 'red'),   #
-        WME('B2', 'on', 'table'),    #
-        WME('B2', 'left-of', 'B3'),  #
-        WME('B2', 'color', 'blue'),  #
-        WME('B3', 'left-of', 'B4'),  #
-        WME('B3', 'on', 'table'),    #
+        WME('B1', 'on', 'B2'),
+        WME('B1', 'on', 'B3'),
+        WME('B1', 'color', 'red'),
+        WME('B2', 'on', 'table'),
+        WME('B2', 'left-of', 'B3'),
+        WME('B2', 'color', 'blue'),
+        WME('B3', 'left-of', 'B4'),
+        WME('B3', 'on', 'table'),
     ]
     for wme in wmes:
         net.add_wme(wme)
-    assert len(list(p0.activations)) == 3
-    assert len(list(p1.activations)) == 3
+    assert len(list(p0.activations)) ==  len(list(p1.activations)) == 3
     net.add_wme(WME('B3', 'color', 'red'))
-    assert len(list(p0.activations)) == 2
-    assert len(list(p1.activations)) == 2
+    assert len(list(p0.activations)) == len(list(p1.activations)) == 2
     net.add_wme(WME('B4', 'color', 'red'))
     net.add_wme(WME('B4', 'on', 'table'))
-    assert len(list(p0.activations)) == 0
-    assert len(list(p1.activations)) == 0
+    assert len(list(p0.activations)) == len(list(p1.activations)) == 0
 
 
 def test_black_white():

--- a/tests/test_beta.py
+++ b/tests/test_beta.py
@@ -402,7 +402,7 @@ def test_ncc():
     c2 = Cond(V('z'), 'color', 'red')
     c3 = Cond(V('z'), 'on', V('w'))
 
-    # @Production(AND(c0, c1, NOT(AND(c2, c3))))
+    #@Production(AND(c0, c1, NOT(AND(c2, c3))))
     @Production(c0 & c1 & ~(c2 & c3))
     def p0():
         pass

--- a/tests/test_beta.py
+++ b/tests/test_beta.py
@@ -156,8 +156,15 @@ class TestOperatorChaining:
         # (True & True | True) => True
         self.check_matches(Production(Filter(lambda: True) & Filter(lambda:True) | Filter(lambda:True)), 2)
 
+    def test_long_chain(self):
+        # True & (False | (True & False)) => False, but gives a false positive
+        self.check_matches(Production(
+            Filter(lambda: True)
+            &  (Filter(lambda:False) | (Filter(lambda: True) & Filter(lambda:False)))
+            ),
+        0)
 
-def test_example():
+def test_filter_is_called():
     net = ReteNetwork()
     def raises():
         raise Exception

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -18,6 +18,14 @@ def test_not2():
     dnf = disjunctive_normal_form(NOT(NOT('A')))
     assert dnf == disjunctive_normal_form('A') == [['A']]
 
+def test_not3():
+    dnf = disjunctive_normal_form(NOT(NOT(OR('A', 'B'))))
+    assert dnf == disjunctive_normal_form(OR('A', 'B'))
+
+def test_not4():
+    dnf = disjunctive_normal_form(NOT(NOT(AND('A', OR('C', 'B')))))
+    assert dnf == disjunctive_normal_form(AND('A', OR('C', 'B')))
+
 def test_not_and():
     dnf = disjunctive_normal_form(NOT(AND('A', 'B')))
     assert dnf == disjunctive_normal_form(OR(NOT('A'), NOT('B')))

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -1,0 +1,52 @@
+from py_rete.conditions import AND, OR, NOT
+
+from py_rete.production import dnf as disjunctive_normal_form
+
+def test_and():
+    dnf = disjunctive_normal_form(AND('A', 'B'))
+    assert dnf == [['A', 'B']]
+
+def test_or():
+    dnf = disjunctive_normal_form(OR('A', 'B'))
+    assert dnf == [['A'], ['B']]
+
+def test_not1():
+    dnf = disjunctive_normal_form(NOT('A'))
+    assert dnf == [[NOT('A')]]
+
+def test_not2():
+    dnf = disjunctive_normal_form(NOT(NOT('A')))
+    assert dnf == disjunctive_normal_form('A') == [['A']]
+
+def test_not_and():
+    dnf = disjunctive_normal_form(NOT(AND('A', 'B')))
+    assert dnf == disjunctive_normal_form(OR(NOT('A'), NOT('B')))
+
+def test_not_or():
+    dnf = disjunctive_normal_form(NOT(OR('A', 'B')))
+    assert dnf == disjunctive_normal_form(AND(NOT('A'), NOT('B')))
+    #assert dnf == disjunctive_normal_form(OR(NOT('A'), NOT('B')))
+
+def test_chain1():
+    dnf = disjunctive_normal_form(AND('A', OR('B', 'C')))
+    assert dnf == [['A', 'B'], ['A', 'C']]
+
+def test_chain2():
+    dnf = disjunctive_normal_form(OR('A', AND('B', 'C')))
+    assert dnf == [['A'], ['B', 'C']]
+
+def test_chain3():
+    dnf = disjunctive_normal_form(OR('A', AND('B', OR('C', 'D'))))
+    assert dnf == [['A'], ['B', 'C'], ['B', 'D']]
+
+def test_chain4():
+    dnf = disjunctive_normal_form(AND('A', OR('B', AND('C', 'D'))))
+    assert dnf == [['A', 'B'], ['A', 'C', 'D']]
+
+def test_chain5():
+    dnf = disjunctive_normal_form(AND('A', OR('B', NOT(OR('C', 'D')))))
+    assert dnf == [['A', 'B'], ['A', NOT('C'), NOT('D')]]
+
+def test_chain6():
+    dnf = disjunctive_normal_form(OR('A', NOT(OR('C', 'D'))))
+    assert dnf == [['A'], [NOT('C'), NOT('D')]] == disjunctive_normal_form(OR('A', AND(NOT('C'), NOT('D'))))

--- a/tests/test_boolean.py
+++ b/tests/test_boolean.py
@@ -1,6 +1,22 @@
-from py_rete.conditions import AND, OR, NOT
+import pytest
 
+from py_rete.conditions import AND, OR, NOT, Filter
 from py_rete.production import dnf as disjunctive_normal_form
+from py_rete.production import Production
+from py_rete.fact import Fact
+
+def test_not_initialization():
+    with pytest.raises(TypeError):
+        NOT('A', 'B')
+
+    with pytest.raises(TypeError):
+        NOT(Filter(lambda: False))
+
+    # These are OK:
+    NOT(AND('A', 'B'))
+    NOT(OR('A', 'B'))
+    Production(~(Fact() | Fact()))
+    Production(~(Fact() & Fact()))
 
 def test_and():
     dnf = disjunctive_normal_form(AND('A', 'B'))
@@ -28,12 +44,11 @@ def test_not4():
 
 def test_not_and():
     dnf = disjunctive_normal_form(NOT(AND('A', 'B')))
-    assert dnf == disjunctive_normal_form(OR(NOT('A'), NOT('B')))
+    assert dnf == disjunctive_normal_form(OR(NOT('A'), NOT('B'))) == [[NOT('A')], [NOT('B')]]
 
 def test_not_or():
     dnf = disjunctive_normal_form(NOT(OR('A', 'B')))
-    assert dnf == disjunctive_normal_form(AND(NOT('A'), NOT('B')))
-    #assert dnf == disjunctive_normal_form(OR(NOT('A'), NOT('B')))
+    assert dnf == disjunctive_normal_form(AND(NOT('A'), NOT('B'))) == [[NOT('A'), NOT('B')]]
 
 def test_chain1():
     dnf = disjunctive_normal_form(AND('A', OR('B', 'C')))


### PR DESCRIPTION
Fixes:

NOT:
* `NOT(NOT(expression))` was not expanded to `expression`, but evaluated into an empty list `[[]]`. Empty list was evaluated as a condition that raised an alert.
* `NOT(AND(A, B))` was not expanded, so logically equivalent expressions: `NOT(AND(A, B))` and `OR(NOT(A), NOT(B))` caused different number of activations.
  * Top-level OR'd conditions should cause an alert for each, and are de-duplicated later
* `NOT(Filter())` caused either false positives or an exception, depending on the value of the filter expression

AND/OR:
* In expressions like `(A & B | C)` or `(A | B & C)` the right/left-hand branch respectively was ignored, resulting in an expression like `[[A], []]` or `[[], [C]]`. Again, an alert was always triggered for the empty list.
* Similarly, for expression like `AND(A, AND(B, C))` the `AND(B, C)` branch was ignored, though `(A & (B & C))` worked as expected (due to parenthesis expansion happening early, due to operator precedence rules).
* Due to the above, any generic expression containing a nested `AND` led to branches that were either silently ignored or caused false positives.

Changes:

* Ambiguous `NOT(A, B)` is not allowed, must use either `(NOT(OR(A,B))` or `NOT(AND(A,B))` or the equivalents `~(A | B)`, `~(A & B)`